### PR TITLE
AUT-120 - secure connection between TARA-Server and eIDAS-Client

### DIFF
--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -132,7 +132,7 @@ Tabel 5.4 - turvaseadistused
 
 | Parameeter        | Kohustuslik | Kirjeldus, näide |
 | :---------------- | :---------- | :----------------|
-| `security.allowedAuthenticationPort` | Ei | Piirab ligipääsu autentimisotspunktidele (`/login` ja `/returnUrl`) vaid kindla pordi kaudu. Lubatud väärtused: täisarv vahemikus 1 - 65535. |
+| `security.allowedAuthenticationPort` | Ei | Olemasolu korral piirab ligipääsu autentimisotspunktidele (`/login` ja `/returnUrl`) vaid määratud pordi kaudu, misjuhul nimetatud otspunktide poole pöördumisel muude portide kaudu tagastatakse `403 Forbidden` ja [veakirjeldus JSON objektina](Service-API.md#veakasitlus). Lubatud väärtused: täisarv vahemikus 1 - 65535. |
 
 Tabel 5.5 - heartbeat otspunkti seadistus
 

--- a/doc/Configuration.md
+++ b/doc/Configuration.md
@@ -128,7 +128,13 @@ Tabel 5.3 - Saadetava AuthnRequesti ja SAML vastuse seadistus
 | `eidas.client.availableCountries` | Ei | Lubatud riigikoodid. |
 | `eidas.client.defaultLoa` | Ei | EIDAS tagatistase juhul kui kasutaja tagatistaseme ise määramata. Lubatud väärtused: 'LOW', 'SUBSTANTIAL', 'HIGH'. Vaikimisi 'SUBSTANTIAL'. |
 
-Tabel 5.4 - heartbeat otspunkti seadistus
+Tabel 5.4 - turvaseadistused
+
+| Parameeter        | Kohustuslik | Kirjeldus, näide |
+| :---------------- | :---------- | :----------------|
+| `security.allowedAuthenticationPort` | Ei | Piirab ligipääsu autentimisotspunktidele (`/login` ja `/returnUrl`) vaid kindla pordi kaudu. Lubatud väärtused: täisarv vahemikus 1 - 65535. |
+
+Tabel 5.5 - heartbeat otspunkti seadistus
 
 | Parameeter        | Kohustuslik | Kirjeldus, näide |
 | :---------------- | :---------- | :----------------|

--- a/doc/Service-API.md
+++ b/doc/Service-API.md
@@ -93,6 +93,7 @@ Näide:
 | 400 | Bad request  | Invalid LoA! One of [...] expected. |
 | 400 | Bad request  | Invalid RelayState! Must match the following regexp: [...] |
 | 400 | Bad request  | Invalid AdditionalParameters! Unrecognized attibute(s) provided: [...] |
+| 403 | Forbidden | Endpoint not allowed to be accessed via port number [...] |
 | 405 | Method Not Allowed | Request method [...] not supported |
 | 500 | Internal Server Error | Something went wrong internally. Please consult server logs for further details. |
 
@@ -170,6 +171,7 @@ Näide:
 | :-------------: |:-------------| :-----|
 | 400 | Bad request | Required String parameter 'SAMLResponse' is not present |
 | 400 | Bad request  | Invalid SAMLResponse. [...] |
+| 403 | Forbidden | Endpoint not allowed to be accessed via port number [...] |
 | 405 | Method Not Allowed | Request method [...] not supported |
 | 500 | Internal Server Error | Something went wrong internally. Please consult server logs for further details. |
 

--- a/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/EidasClientApi.java
+++ b/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/EidasClientApi.java
@@ -1,0 +1,42 @@
+package ee.ria.eidas.client.webapp;
+
+public class EidasClientApi {
+
+    public static final String ENDPOINT_METADATA_METADATA = "/metadata";
+    public static final String ENDPOINT_METADATA_SUPPORTED_COUNTRIES = "/supportedCountries";
+
+    public static final String ENDPOINT_AUTHENTICATION_LOGIN = "/login";
+    public static final String ENDPOINT_AUTHENTICATION_RETURN_URL = "/returnUrl";
+
+
+    public static enum Endpoint {
+
+        METADATA(ENDPOINT_METADATA_METADATA, Type.METADATA),
+        SUPPORTED_COUNTRIES(ENDPOINT_METADATA_SUPPORTED_COUNTRIES, Type.METADATA),
+
+        LOGIN(ENDPOINT_AUTHENTICATION_LOGIN, Type.AUTHENTICATION),
+        RETURN_URL(ENDPOINT_AUTHENTICATION_RETURN_URL, Type.AUTHENTICATION);
+
+        public static enum Type {
+            METADATA, AUTHENTICATION;
+        }
+
+        public final String urlPattern;
+        public final Type type;
+
+        Endpoint(String urlPattern, Type type) {
+            this.urlPattern = urlPattern;
+            this.type = type;
+        }
+
+        public String getUrlPattern() {
+            return this.urlPattern;
+        }
+
+        public Type getType() {
+            return this.type;
+        }
+
+    }
+
+}

--- a/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/controller/AuthenticationController.java
+++ b/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/controller/AuthenticationController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import static ee.ria.eidas.client.webapp.EidasClientApi.ENDPOINT_AUTHENTICATION_LOGIN;
+import static ee.ria.eidas.client.webapp.EidasClientApi.ENDPOINT_AUTHENTICATION_RETURN_URL;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 import static org.springframework.web.bind.annotation.RequestMethod.POST;
 
@@ -38,7 +40,7 @@ public class AuthenticationController {
         binder.registerCustomEditor(String.class, new StringTrimmerEditor(true));
     }
 
-    @RequestMapping(value = "/login", method = GET)
+    @RequestMapping(value = ENDPOINT_AUTHENTICATION_LOGIN, method = GET)
     public void authenticate(HttpServletResponse response,
             @RequestParam("Country") String country,
             @RequestParam(value = "LoA", required=false) AssuranceLevel loa,
@@ -47,7 +49,7 @@ public class AuthenticationController {
         authInitiationService.authenticate(response, country, loa, relayState, additionalAttributes);
     }
 
-    @RequestMapping(value = "/returnUrl", method = POST)
+    @RequestMapping(value = ENDPOINT_AUTHENTICATION_RETURN_URL, method = POST)
     @ResponseBody
     public AuthenticationResult getAuthenticationResult(HttpServletRequest req) throws MissingServletRequestParameterException {
         return authResponseService.getAuthenticationResult(req);

--- a/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/controller/MetadataController.java
+++ b/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/controller/MetadataController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.ResponseBody;
 
 import java.util.List;
 
+import static ee.ria.eidas.client.webapp.EidasClientApi.ENDPOINT_METADATA_METADATA;
+import static ee.ria.eidas.client.webapp.EidasClientApi.ENDPOINT_METADATA_SUPPORTED_COUNTRIES;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
 
 @Controller
@@ -23,13 +25,13 @@ public class MetadataController {
     @Autowired
     private SPMetadataGenerator metadataGenerator;
 
-    @RequestMapping(value = "/metadata", method = GET, produces = { "application/xml", "text/xml" }, consumes = MediaType.ALL_VALUE)
+    @RequestMapping(value = ENDPOINT_METADATA_METADATA, method = GET, produces = { "application/xml", "text/xml" }, consumes = MediaType.ALL_VALUE)
     public @ResponseBody String metadata() {
         EntityDescriptor entityDescriptor = metadataGenerator.getMetadata();
         return OpenSAMLUtils.getXmlString(entityDescriptor);
     }
 
-    @RequestMapping(value = "/supportedCountries", method = GET, produces = { "application/json" }, consumes = MediaType.ALL_VALUE)
+    @RequestMapping(value = ENDPOINT_METADATA_SUPPORTED_COUNTRIES, method = GET, produces = { "application/json" }, consumes = MediaType.ALL_VALUE)
     public @ResponseBody List<String> countries() {
         return eidasClientProperties.getAvailableCountries();
     }

--- a/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/AuthenticationPortFilter.java
+++ b/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/AuthenticationPortFilter.java
@@ -9,6 +9,12 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.PrintWriter;
 
+/**
+ * This filter allows to limit access (to certain URL patterns) via one specific port.
+ * When incoming request's local port number equals the allowed port number, then the processing of the incoming request is continued as if this filter didn't exist.
+ * When incoming request's local port number is anything else but the allowed port number, then the further processing of the incoming request is stopped
+ * and a 403 response, with a simple JSON object describing the error, is sent.
+ */
 public class AuthenticationPortFilter implements Filter {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationPortFilter.class);

--- a/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/AuthenticationPortFilter.java
+++ b/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/AuthenticationPortFilter.java
@@ -1,0 +1,57 @@
+package ee.ria.eidas.client.webapp.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.PrintWriter;
+
+public class AuthenticationPortFilter implements Filter {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AuthenticationPortFilter.class);
+
+    private final int allowedPort;
+
+    public AuthenticationPortFilter(final int allowedPort) {
+        this.allowedPort = allowedPort;
+    }
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        if (servletRequest.getLocalPort() == this.allowedPort) {
+            filterChain.doFilter(servletRequest, servletResponse);
+        } else {
+            sendForbiddenResponse((HttpServletResponse) servletResponse, String.format(
+                    "Endpoint not allowed to be accessed via port number %d",
+                    servletRequest.getLocalPort()
+            ));
+        }
+    }
+
+    @Override
+    public void destroy() {
+    }
+
+    private static void sendForbiddenResponse(final HttpServletResponse response, final String message) throws IOException {
+        LOGGER.error(message);
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType("application/json;charset=UTF-8");
+
+        try (PrintWriter writer = response.getWriter()) {
+            writer.format("{\"error\":\"%s\",\"message\":\"%s\"}",
+                    HttpStatus.FORBIDDEN.getReasonPhrase(),
+                    message
+            );
+            writer.flush();
+        }
+    }
+
+}

--- a/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/SecurityConfiguration.java
+++ b/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/SecurityConfiguration.java
@@ -1,0 +1,40 @@
+package ee.ria.eidas.client.webapp.security;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+
+import java.util.Arrays;
+import java.util.HashMap;
+
+@Configuration
+public class SecurityConfiguration {
+
+    @Autowired
+    private Environment environment;
+
+    @Bean
+    @ConditionalOnProperty("security.allowedAuthenticationPort")
+    public FilterRegistrationBean authenticationPortFilter() {
+        final int allowedPort = Integer.parseInt(
+                environment.getProperty("security.allowedAuthenticationPort")
+        );
+        if (allowedPort < 1 || allowedPort > 65535) {
+            throw new IllegalStateException("Illegal port number " + allowedPort);
+        }
+
+        final FilterRegistrationBean bean = new FilterRegistrationBean();
+        bean.setFilter(new AuthenticationPortFilter(allowedPort));
+        bean.setUrlPatterns(Arrays.asList("/login", "/returnUrl"));
+        bean.setInitParameters(new HashMap<>());
+        bean.setName("authenticationPortFilter");
+        bean.setOrder(Ordered.HIGHEST_PRECEDENCE + 2);
+
+        return bean;
+    }
+
+}

--- a/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/SecurityConfiguration.java
+++ b/eidas-client-webapp/src/main/java/ee/ria/eidas/client/webapp/security/SecurityConfiguration.java
@@ -1,5 +1,6 @@
 package ee.ria.eidas.client.webapp.security;
 
+import ee.ria.eidas.client.webapp.EidasClientApi;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
@@ -10,6 +11,7 @@ import org.springframework.core.env.Environment;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.stream.Collectors;
 
 @Configuration
 public class SecurityConfiguration {
@@ -29,10 +31,15 @@ public class SecurityConfiguration {
 
         final FilterRegistrationBean bean = new FilterRegistrationBean();
         bean.setFilter(new AuthenticationPortFilter(allowedPort));
-        bean.setUrlPatterns(Arrays.asList("/login", "/returnUrl"));
         bean.setInitParameters(new HashMap<>());
         bean.setName("authenticationPortFilter");
         bean.setOrder(Ordered.HIGHEST_PRECEDENCE + 2);
+        bean.setUrlPatterns(
+                Arrays.stream(EidasClientApi.Endpoint.values())
+                        .filter(ep -> ep.getType() == EidasClientApi.Endpoint.Type.AUTHENTICATION)
+                        .map(ep -> ep.getUrlPattern())
+                        .collect(Collectors.toList())
+        );
 
         return bean;
     }

--- a/eidas-client-webapp/src/test/java/ee/ria/eidas/client/webapp/security/AuthenticationPortFilterTest.java
+++ b/eidas-client-webapp/src/test/java/ee/ria/eidas/client/webapp/security/AuthenticationPortFilterTest.java
@@ -1,0 +1,77 @@
+package ee.ria.eidas.client.webapp.security;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+import org.skyscreamer.jsonassert.JSONAssert;
+import org.springframework.http.HttpStatus;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import javax.servlet.FilterChain;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+public class AuthenticationPortFilterTest {
+
+    private static final int TEST_PORT_NUMBER = 12345;
+
+    private AuthenticationPortFilter filter;
+
+    @Before
+    public void setUp() {
+        this.filter = new AuthenticationPortFilter(TEST_PORT_NUMBER);
+    }
+
+    @After
+    public void cleanUp() {
+        this.filter.destroy();
+        this.filter = null;
+    }
+
+    @Test
+    public void doFilterShouldDoNothingWhenRequestHasAllowedPort() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        HttpServletResponse response = Mockito.mock(HttpServletResponse.class);
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        Mockito.doReturn(TEST_PORT_NUMBER).when(request).getLocalPort();
+
+        this.filter.doFilter(request, response, filterChain);
+
+        Mockito.verifyZeroInteractions(response);
+        Mockito.verify(filterChain, Mockito.times(1))
+                .doFilter(request, response);
+    }
+
+    @Test
+    public void doFilterShouldRespondErrorWhenRequestDoesntHaveAllowedPort() throws Exception {
+        HttpServletRequest request = Mockito.mock(HttpServletRequest.class);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        FilterChain filterChain = Mockito.mock(FilterChain.class);
+
+        final int portNumber = TEST_PORT_NUMBER + 1;
+        Mockito.doReturn(portNumber).when(request).getLocalPort();
+
+        this.filter.doFilter(request, response, filterChain);
+
+        Mockito.verifyZeroInteractions(filterChain);
+        verifyErroneousResponse(response, portNumber);
+    }
+
+    private static void verifyErroneousResponse(final MockHttpServletResponse response, final int portNumber) throws Exception {
+        Assert.assertEquals(HttpStatus.FORBIDDEN.value(), response.getStatus());
+        Assert.assertEquals("application/json;charset=UTF-8", response.getContentType());
+
+        JSONAssert.assertEquals(
+                String.format("{" +
+                        "\"error\": \"Forbidden\", " +
+                        "\"message\": \"Endpoint not allowed to be accessed via port number %d\"" +
+                        "}", portNumber),
+                response.getContentAsString(),
+                true
+        );
+    }
+
+}

--- a/eidas-client-webapp/src/test/java/ee/ria/eidas/client/webapp/security/SecurityConfigurationTest.java
+++ b/eidas-client-webapp/src/test/java/ee/ria/eidas/client/webapp/security/SecurityConfigurationTest.java
@@ -1,0 +1,94 @@
+package ee.ria.eidas.client.webapp.security;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.core.Ordered;
+import org.springframework.core.env.Environment;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SecurityConfigurationTest {
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Mock
+    private Environment environment;
+
+    @Autowired
+    @InjectMocks
+    private SecurityConfiguration configuration;
+
+    @Before
+    public void setUp() {
+        Mockito.reset(environment);
+    }
+
+    @Test
+    public void authenticationPortFilterShouldReturnValidFilter() {
+        Mockito.doReturn("12345").when(environment)
+                .getProperty("security.allowedAuthenticationPort");
+
+        FilterRegistrationBean bean = configuration.authenticationPortFilter();
+        Assert.assertTrue(AuthenticationPortFilter.class.isInstance(bean.getFilter()));
+        Assert.assertEquals(new HashSet<>(Arrays.asList("/login", "/returnUrl")), bean.getUrlPatterns());
+        Assert.assertEquals(Ordered.HIGHEST_PRECEDENCE + 2, bean.getOrder());
+    }
+
+    @Test
+    public void authenticationPortFilterShouldFailWhenAllowedPortIsZero() {
+        Mockito.doReturn("0").when(environment)
+                .getProperty("security.allowedAuthenticationPort");
+
+        expectedEx.expect(IllegalStateException.class);
+        expectedEx.expectMessage("Illegal port number 0");
+
+        configuration.authenticationPortFilter();
+    }
+
+    @Test
+    public void authenticationPortFilterShouldFailWhenAllowedPortIsNegative() {
+        Mockito.doReturn("-1").when(environment)
+                .getProperty("security.allowedAuthenticationPort");
+
+        expectedEx.expect(IllegalStateException.class);
+        expectedEx.expectMessage("Illegal port number -1");
+
+        configuration.authenticationPortFilter();
+    }
+
+    @Test
+    public void authenticationPortFilterShouldFailWhenAllowedPortIsAbove65535() {
+        Mockito.doReturn("65536").when(environment)
+                .getProperty("security.allowedAuthenticationPort");
+
+        expectedEx.expect(IllegalStateException.class);
+        expectedEx.expectMessage("Illegal port number 65536");
+
+        configuration.authenticationPortFilter();
+    }
+
+    @Test
+    public void authenticationPortFilterShouldFailWhenAllowedPortIsNotANumber() {
+        Mockito.doReturn("abc").when(environment)
+                .getProperty("security.allowedAuthenticationPort");
+
+        expectedEx.expect(NumberFormatException.class);
+        expectedEx.expectMessage("For input string: \"abc\"");
+
+        configuration.authenticationPortFilter();
+    }
+
+}


### PR DESCRIPTION
Added a filter to be able to limit access to authentication endpoints to a certain port. Useful when running the application on multiple ports with different security.